### PR TITLE
feat: inject github link

### DIFF
--- a/articles/bocchi.html
+++ b/articles/bocchi.html
@@ -168,6 +168,21 @@ AFAIK no street address; I typically use &quot;123 Downstairs&quot; because it i
 
 
 	</article>
+	<div id="clicky"><a style="display:none;" href="#">Click here to go to GitHub!</a></div>
+	<script>
+		function injectClicky(event) {
+			if (event.origin !== 'https://giscus.app') return;
+			if (!(typeof event.data === 'object' && event.data.giscus)) return;
+			const giscusData = event.data.giscus;
+			if ('discussion' in giscusData) {
+				const clicky = document.querySelector('#clicky a');
+				clicky.href = giscusData.discussion.url;
+				clicky.style.display = "";
+				window.removeEventListener('message', injectClicky);
+			}
+		}
+		window.addEventListener('message', injectClicky);
+	</script>
 	<script src="https://giscus.app/client.js"
 		data-repo="zephyrtronium/zephyrtronium.github.io"
 		data-repo-id="MDEwOlJlcG9zaXRvcnkyNjEwNDIxNTQ="
@@ -175,7 +190,7 @@ AFAIK no street address; I typically use &quot;123 Downstairs&quot; because it i
 		data-category-id="DIC_kwDOD48v6s4B_JuI"
 		data-mapping="og:title"
 		data-reactions-enabled="1"
-		data-emit-metadata="0"
+		data-emit-metadata="1"
 		data-theme="https://zephyrtronium.github.io/style/giscus.css"
 		crossorigin="anonymous"
 		async>

--- a/articles/copilot.html
+++ b/articles/copilot.html
@@ -112,6 +112,21 @@ The training corpus usually doesn't appear anywhere within the model in any read
 
 
 	</article>
+	<div id="clicky"><a style="display:none;" href="#">Click here to go to GitHub!</a></div>
+	<script>
+		function injectClicky(event) {
+			if (event.origin !== 'https://giscus.app') return;
+			if (!(typeof event.data === 'object' && event.data.giscus)) return;
+			const giscusData = event.data.giscus;
+			if ('discussion' in giscusData) {
+				const clicky = document.querySelector('#clicky a');
+				clicky.href = giscusData.discussion.url;
+				clicky.style.display = "";
+				window.removeEventListener('message', injectClicky);
+			}
+		}
+		window.addEventListener('message', injectClicky);
+	</script>
 	<script src="https://giscus.app/client.js"
 		data-repo="zephyrtronium/zephyrtronium.github.io"
 		data-repo-id="MDEwOlJlcG9zaXRvcnkyNjEwNDIxNTQ="
@@ -119,7 +134,7 @@ The training corpus usually doesn't appear anywhere within the model in any read
 		data-category-id="DIC_kwDOD48v6s4B_JuI"
 		data-mapping="og:title"
 		data-reactions-enabled="1"
-		data-emit-metadata="0"
+		data-emit-metadata="1"
 		data-theme="https://zephyrtronium.github.io/style/giscus.css"
 		crossorigin="anonymous"
 		async>

--- a/articles/generics-enums.html
+++ b/articles/generics-enums.html
@@ -114,6 +114,21 @@ func main() {
 
 
 	</article>
+	<div id="clicky"><a style="display:none;" href="#">Click here to go to GitHub!</a></div>
+	<script>
+		function injectClicky(event) {
+			if (event.origin !== 'https://giscus.app') return;
+			if (!(typeof event.data === 'object' && event.data.giscus)) return;
+			const giscusData = event.data.giscus;
+			if ('discussion' in giscusData) {
+				const clicky = document.querySelector('#clicky a');
+				clicky.href = giscusData.discussion.url;
+				clicky.style.display = "";
+				window.removeEventListener('message', injectClicky);
+			}
+		}
+		window.addEventListener('message', injectClicky);
+	</script>
 	<script src="https://giscus.app/client.js"
 		data-repo="zephyrtronium/zephyrtronium.github.io"
 		data-repo-id="MDEwOlJlcG9zaXRvcnkyNjEwNDIxNTQ="
@@ -121,7 +136,7 @@ func main() {
 		data-category-id="DIC_kwDOD48v6s4B_JuI"
 		data-mapping="og:title"
 		data-reactions-enabled="1"
-		data-emit-metadata="0"
+		data-emit-metadata="1"
 		data-theme="https://zephyrtronium.github.io/style/giscus.css"
 		crossorigin="anonymous"
 		async>

--- a/articles/randomness.html
+++ b/articles/randomness.html
@@ -405,6 +405,21 @@ Like in the section on platform CSPRNGs, using your own Source is mostly a matte
 
 
 	</article>
+	<div id="clicky"><a style="display:none;" href="#">Click here to go to GitHub!</a></div>
+	<script>
+		function injectClicky(event) {
+			if (event.origin !== 'https://giscus.app') return;
+			if (!(typeof event.data === 'object' && event.data.giscus)) return;
+			const giscusData = event.data.giscus;
+			if ('discussion' in giscusData) {
+				const clicky = document.querySelector('#clicky a');
+				clicky.href = giscusData.discussion.url;
+				clicky.style.display = "";
+				window.removeEventListener('message', injectClicky);
+			}
+		}
+		window.addEventListener('message', injectClicky);
+	</script>
 	<script src="https://giscus.app/client.js"
 		data-repo="zephyrtronium/zephyrtronium.github.io"
 		data-repo-id="MDEwOlJlcG9zaXRvcnkyNjEwNDIxNTQ="
@@ -412,7 +427,7 @@ Like in the section on platform CSPRNGs, using your own Source is mostly a matte
 		data-category-id="DIC_kwDOD48v6s4B_JuI"
 		data-mapping="og:title"
 		data-reactions-enabled="1"
-		data-emit-metadata="0"
+		data-emit-metadata="1"
 		data-theme="https://zephyrtronium.github.io/style/giscus.css"
 		crossorigin="anonymous"
 		async>

--- a/articles/rwmutex.html
+++ b/articles/rwmutex.html
@@ -328,6 +328,21 @@ Whatever brought you to this point, you should be aware that performance will ve
 
 
 	</article>
+	<div id="clicky"><a style="display:none;" href="#">Click here to go to GitHub!</a></div>
+	<script>
+		function injectClicky(event) {
+			if (event.origin !== 'https://giscus.app') return;
+			if (!(typeof event.data === 'object' && event.data.giscus)) return;
+			const giscusData = event.data.giscus;
+			if ('discussion' in giscusData) {
+				const clicky = document.querySelector('#clicky a');
+				clicky.href = giscusData.discussion.url;
+				clicky.style.display = "";
+				window.removeEventListener('message', injectClicky);
+			}
+		}
+		window.addEventListener('message', injectClicky);
+	</script>
 	<script src="https://giscus.app/client.js"
 		data-repo="zephyrtronium/zephyrtronium.github.io"
 		data-repo-id="MDEwOlJlcG9zaXRvcnkyNjEwNDIxNTQ="
@@ -335,7 +350,7 @@ Whatever brought you to this point, you should be aware that performance will ve
 		data-category-id="DIC_kwDOD48v6s4B_JuI"
 		data-mapping="og:title"
 		data-reactions-enabled="1"
-		data-emit-metadata="0"
+		data-emit-metadata="1"
 		data-theme="https://zephyrtronium.github.io/style/giscus.css"
 		crossorigin="anonymous"
 		async>

--- a/articles/static-assert.html
+++ b/articles/static-assert.html
@@ -211,6 +211,21 @@ When they're useful, they make code substantially more robust.</p>
 
 
 	</article>
+	<div id="clicky"><a style="display:none;" href="#">Click here to go to GitHub!</a></div>
+	<script>
+		function injectClicky(event) {
+			if (event.origin !== 'https://giscus.app') return;
+			if (!(typeof event.data === 'object' && event.data.giscus)) return;
+			const giscusData = event.data.giscus;
+			if ('discussion' in giscusData) {
+				const clicky = document.querySelector('#clicky a');
+				clicky.href = giscusData.discussion.url;
+				clicky.style.display = "";
+				window.removeEventListener('message', injectClicky);
+			}
+		}
+		window.addEventListener('message', injectClicky);
+	</script>
 	<script src="https://giscus.app/client.js"
 		data-repo="zephyrtronium/zephyrtronium.github.io"
 		data-repo-id="MDEwOlJlcG9zaXRvcnkyNjEwNDIxNTQ="
@@ -218,7 +233,7 @@ When they're useful, they make code substantially more robust.</p>
 		data-category-id="DIC_kwDOD48v6s4B_JuI"
 		data-mapping="og:title"
 		data-reactions-enabled="1"
-		data-emit-metadata="0"
+		data-emit-metadata="1"
 		data-theme="https://zephyrtronium.github.io/style/giscus.css"
 		crossorigin="anonymous"
 		async>

--- a/articles/syncmap.html
+++ b/articles/syncmap.html
@@ -355,6 +355,21 @@ func (e *entry) delete() {
 
 
 	</article>
+	<div id="clicky"><a style="display:none;" href="#">Click here to go to GitHub!</a></div>
+	<script>
+		function injectClicky(event) {
+			if (event.origin !== 'https://giscus.app') return;
+			if (!(typeof event.data === 'object' && event.data.giscus)) return;
+			const giscusData = event.data.giscus;
+			if ('discussion' in giscusData) {
+				const clicky = document.querySelector('#clicky a');
+				clicky.href = giscusData.discussion.url;
+				clicky.style.display = "";
+				window.removeEventListener('message', injectClicky);
+			}
+		}
+		window.addEventListener('message', injectClicky);
+	</script>
 	<script src="https://giscus.app/client.js"
 		data-repo="zephyrtronium/zephyrtronium.github.io"
 		data-repo-id="MDEwOlJlcG9zaXRvcnkyNjEwNDIxNTQ="
@@ -362,7 +377,7 @@ func (e *entry) delete() {
 		data-category-id="DIC_kwDOD48v6s4B_JuI"
 		data-mapping="og:title"
 		data-reactions-enabled="1"
-		data-emit-metadata="0"
+		data-emit-metadata="1"
 		data-theme="https://zephyrtronium.github.io/style/giscus.css"
 		crossorigin="anonymous"
 		async>

--- a/articles/unmarshal-validation.html
+++ b/articles/unmarshal-validation.html
@@ -235,6 +235,21 @@ What we've achieved is an important insight in programming language theory: safe
 
 
 	</article>
+	<div id="clicky"><a style="display:none;" href="#">Click here to go to GitHub!</a></div>
+	<script>
+		function injectClicky(event) {
+			if (event.origin !== 'https://giscus.app') return;
+			if (!(typeof event.data === 'object' && event.data.giscus)) return;
+			const giscusData = event.data.giscus;
+			if ('discussion' in giscusData) {
+				const clicky = document.querySelector('#clicky a');
+				clicky.href = giscusData.discussion.url;
+				clicky.style.display = "";
+				window.removeEventListener('message', injectClicky);
+			}
+		}
+		window.addEventListener('message', injectClicky);
+	</script>
 	<script src="https://giscus.app/client.js"
 		data-repo="zephyrtronium/zephyrtronium.github.io"
 		data-repo-id="MDEwOlJlcG9zaXRvcnkyNjEwNDIxNTQ="
@@ -242,7 +257,7 @@ What we've achieved is an important insight in programming language theory: safe
 		data-category-id="DIC_kwDOD48v6s4B_JuI"
 		data-mapping="og:title"
 		data-reactions-enabled="1"
-		data-emit-metadata="0"
+		data-emit-metadata="1"
 		data-theme="https://zephyrtronium.github.io/style/giscus.css"
 		crossorigin="anonymous"
 		async>

--- a/style/giscus.css
+++ b/style/giscus.css
@@ -25,3 +25,7 @@
         --color-btn-hover-bg: #101210;
     }
 }
+
+.gsc-reactions-count {
+    display: none;
+}

--- a/style/zephyrtronium.css
+++ b/style/zephyrtronium.css
@@ -122,6 +122,8 @@ hr {
     border-color: #2b7c00;
 }
 
-.giscus {
+#clicky {
     margin-top: 1em;
+    display: block;
+    text-align: center;
 }


### PR DESCRIPTION
This should probably be two commits, let me know if you want me to split them for review. 

This is the result of
1. Applying https://github.com/zephyrtronium/articles/pull/1 to the articles
2. Modifying the CSS for Giscus to hide the reactions link.